### PR TITLE
Use "current_timestamp" instead of "'now'"

### DIFF
--- a/lib/DBI/Filesystem/DBD/Pg.pm
+++ b/lib/DBI/Filesystem/DBD/Pg.pm
@@ -75,7 +75,7 @@ sub _get_unix_timestamp_sql {
 }
 
 sub _now_sql {
-    return "'now'";
+    return "current_timestamp";
 }
 
 sub _update_utime_sql {


### PR DESCRIPTION
Use "current_timestamp", because now does not seem to work ( maybe "now()" would be more appropriate) -- issue discovered while testing using cockroach db beta-20161215